### PR TITLE
chore: add base tsconfig and restructure api imports

### DIFF
--- a/packages/api/src/jobs/ai/create_digest.ts
+++ b/packages/api/src/jobs/ai/create_digest.ts
@@ -6,7 +6,7 @@ import {
   htmlToSpeechFile,
   SpeechFile,
   SSMLOptions,
-} from '../../../../text-to-speech/src/htmlToSsml'
+} from '@omnivore/text-to-speech-handler/build/src/htmlToSsml'
 import axios from 'axios'
 import { truncate } from 'lodash'
 import { v4 as uuid } from 'uuid'

--- a/packages/api/src/jobs/email/inbound_emails.ts
+++ b/packages/api/src/jobs/email/inbound_emails.ts
@@ -1,4 +1,4 @@
-import { handleNewsletter } from '../../../../content-handler/src/index'
+import { handleNewsletter } from '@omnivore/content-handler'
 import { Converter } from 'showdown'
 import { ContentReaderType, LibraryItemState } from '../../entity/library_item'
 import { SubscriptionStatus } from '../../entity/subscription'

--- a/packages/api/src/jobs/trigger_rule.ts
+++ b/packages/api/src/jobs/trigger_rule.ts
@@ -1,4 +1,4 @@
-import { LiqeQuery } from '../../../liqe/src/Liqe'
+import { LiqeQuery } from '@omnivore/liqe'
 import axios from 'axios'
 import { Any } from 'typeorm'
 import { ReadingProgressDataSource } from '../datasources/reading_progress_data_source'

--- a/packages/api/src/routers/ai_summary_router.ts
+++ b/packages/api/src/routers/ai_summary_router.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { htmlToSpeechFile } from '../../../text-to-speech/src/htmlToSsml'
+import { htmlToSpeechFile } from '@omnivore/text-to-speech-handler/build/src/htmlToSsml'
 import cors from 'cors'
 import express from 'express'
 import { userRepository } from '../repository/user'

--- a/packages/api/src/routers/article_router.ts
+++ b/packages/api/src/routers/article_router.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { htmlToSpeechFile } from '../../../text-to-speech/src/htmlToSsml'
+import { htmlToSpeechFile } from '@omnivore/text-to-speech-handler/build/src/htmlToSsml'
 import cors from 'cors'
 import express from 'express'
 import * as jwt from 'jsonwebtoken'

--- a/packages/api/src/services/digest.ts
+++ b/packages/api/src/services/digest.ts
@@ -1,4 +1,4 @@
-import { SpeechFile } from '../../../text-to-speech/src/htmlToSsml'
+import { SpeechFile } from '@omnivore/text-to-speech-handler/build/src/htmlToSsml'
 import { TaskState } from '../generated/graphql'
 import { redisDataSource } from '../redis_data_source'
 import { logger } from '../utils/logger'

--- a/packages/api/src/services/library_item.ts
+++ b/packages/api/src/services/library_item.ts
@@ -1,4 +1,4 @@
-import { ExpressionToken, LiqeQuery } from '../../../liqe/src/Liqe'
+import { ExpressionToken, LiqeQuery } from '@omnivore/liqe'
 import { camelCase } from 'lodash'
 import { DateTime } from 'luxon'
 import {

--- a/packages/api/src/utils/parser.ts
+++ b/packages/api/src/utils/parser.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-base-to-string */
 
-import { preParseContent } from '../../../content-handler/src/index'
+import { preParseContent } from '@omnivore/content-handler'
 import { Readability } from '@omnivore/readability'
 import addressparser from 'addressparser'
 import axios from 'axios'

--- a/packages/api/src/utils/search.ts
+++ b/packages/api/src/utils/search.ts
@@ -1,4 +1,4 @@
-import { LiqeQuery, parse } from '../../../liqe/src/Liqe'
+import { LiqeQuery, parse } from '@omnivore/liqe'
 
 export const parseSearchQuery = (query: string): LiqeQuery => {
   let searchQuery = query

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
@@ -10,7 +10,9 @@
     "strict": false,
     "lib": ["ES2020"],
     "allowJs": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "composite": true,
+    "declaration": true
   },
   "include": [
     "src/**/*.ts",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+
+  "compilerOptions": {
+    "lib": ["es2020", "dom"],
+    "module": "commonjs",
+    "target": "es2020",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/tsconfig",
-
-  "compilerOptions": {
-    "lib": ["es2020", "dom"],
-    "module": "commonjs",
-    "target": "es2020",
-
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "experimentalDecorators": true
-  }
+  "files": [],
+  "references": [{ "path": "./packages/api" }]
 }


### PR DESCRIPTION
## Summary
- introduce repo-wide tsconfig.base.json and solution config
- point API package at base config with composite build settings
- switch API imports to consume other packages via workspace modules

## Testing
- `npm run build --workspace @omnivore/api` *(fails: Property 'forEach' does not exist on type 'unknown'; The inferred type of 'aiSummariesRouter' cannot be named without a reference to 'express/node_modules/@types/express-serve-static-core')*

------
https://chatgpt.com/codex/tasks/task_e_6897ab536f448332be1085a58996af52